### PR TITLE
Unique ACL routes

### DIFF
--- a/lib/HaproxyManager.js
+++ b/lib/HaproxyManager.js
@@ -143,8 +143,13 @@ handlebars.registerHelper('frontendHelper', function (frontend) {
   }
 
   if (hasRules) {
+    var routeNames = [];
     frontend.rules.forEach(function (rule) {
       var rand = Math.random().toString(36).substring(3);
+      while(routeNames.indexOf(rand) >= 0){
+        rand = Math.random().toString(36).substring(3);
+      }
+      routeNames.push(rand);
       var name = rule.type + '_' + rand;
 
       if (rule.type === 'path' || rule.type === 'url') {


### PR DESCRIPTION
Track previously generated names so new routes don't accidentally
receive the same one.